### PR TITLE
force send params to lowercase

### DIFF
--- a/MailGunClient.cfc
+++ b/MailGunClient.cfc
@@ -46,19 +46,19 @@
 			var result   = "";
 			var files    = {};
 			var postVars = {
-				  from    = arguments.from
-				, to      = arguments.to
-				, subject = arguments.subject
-				, text    = arguments.text
-				, html    = arguments.html
+				  "from"    = arguments.from
+				, "to"      = arguments.to
+				, "subject" = arguments.subject
+				, "text"    = arguments.text
+				, "html"    = arguments.html
 			};
 
 			if ( Len( Trim( arguments.cc ) ) ) {
-				postVars.cc = arguments.cc;
+				postVars[ "cc" ] = arguments.cc;
 			}
 
 			if ( Len( Trim( arguments.bcc ) ) ) {
-				postVars.bcc = arguments.bcc;
+				postVars[ "bcc" ] = arguments.bcc;
 			}
 
 			if ( _getForceTestMode() or arguments.testMode ) {


### PR DESCRIPTION
Force keys for `sendMessage` to be lowercase. All tests are green.

Addresses issue https://github.com/DominicWatson/cfmailgun/issues/58
